### PR TITLE
Aligned to changes in oM - moving Reflection_oM objects to Base_oM plus IFCSettings to inherit from BHoMObject

### DIFF
--- a/IFC_Adapter/AdapterActions/Execute.cs
+++ b/IFC_Adapter/AdapterActions/Execute.cs
@@ -21,7 +21,7 @@
  */
 
 using BH.oM.Adapter;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System;
 using System.Collections.Generic;
 
@@ -35,9 +35,9 @@ namespace BH.Adapter.IFC
 
         [MultiOutput(0, "success", "List of booleans indicating whether the command succeeded for the individual items.")]
         [MultiOutput(1, "globalSuccess", "Bool indicating whether the command succeded for all the provided inputs.")]
-        public override oM.Reflection.Output<List<object>, bool> Execute(IExecuteCommand command, ActionConfig actionConfig = null)
+        public override oM.Base.Output<List<object>, bool> Execute(IExecuteCommand command, ActionConfig actionConfig = null)
         {
-            BH.Engine.Reflection.Compute.RecordError("Execute action is not implemented in the IFC_Toolkit");
+            BH.Engine.Base.Compute.RecordError("Execute action is not implemented in the IFC_Toolkit");
             return null;
         }
 

--- a/IFC_Adapter/AdapterActions/Pull.cs
+++ b/IFC_Adapter/AdapterActions/Pull.cs
@@ -36,7 +36,7 @@ namespace BH.Adapter.IFC
         {
             if (m_LoadedModel == null)
             {
-                Engine.Reflection.Compute.RecordWarning("The .ifc file has not been loaded correctly.");
+                Engine.Base.Compute.RecordWarning("The .ifc file has not been loaded correctly.");
                 return new List<object>();
             }
 

--- a/IFC_Adapter/AdapterActions/Push.cs
+++ b/IFC_Adapter/AdapterActions/Push.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.IFC
         {
             if (m_LoadedModel == null)
             {
-                Engine.Reflection.Compute.RecordWarning("The .ifc file has not been loaded correctly.");
+                Engine.Base.Compute.RecordWarning("The .ifc file has not been loaded correctly.");
                 return new List<object>();
             }
 
@@ -52,7 +52,7 @@ namespace BH.Adapter.IFC
                 }
                 catch (Exception e)
                 {
-                    BH.Engine.Reflection.Compute.RecordError($"Push to IFC failed with the following error message:\n{e.Message}");
+                    BH.Engine.Base.Compute.RecordError($"Push to IFC failed with the following error message:\n{e.Message}");
                     return new List<object>();
                 }
             }

--- a/IFC_Adapter/AdapterActions/Remove.cs
+++ b/IFC_Adapter/AdapterActions/Remove.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.IFC
 
         public override int Remove(IRequest request, ActionConfig actionConfig = null)
         {
-            BH.Engine.Reflection.Compute.RecordError("Remove action is not implemented in the IFC_Toolkit");
+            BH.Engine.Base.Compute.RecordError("Remove action is not implemented in the IFC_Toolkit");
             return 0;
         }
 

--- a/IFC_Adapter/CRUD/Read.cs
+++ b/IFC_Adapter/CRUD/Read.cs
@@ -44,7 +44,7 @@ namespace BH.Adapter.IFC
         {
             if (request == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("The request is null, pull failed.");
+                BH.Engine.Base.Compute.RecordError("The request is null, pull failed.");
                 return new List<IBHoMObject>();
             }
 
@@ -53,7 +53,7 @@ namespace BH.Adapter.IFC
             if (config == null)
             {
                 config = new IfcPullConfig();
-                BH.Engine.Reflection.Compute.RecordNote("Config has not been specified, default config is used.");
+                BH.Engine.Base.Compute.RecordNote("Config has not been specified, default config is used.");
             }
 
             // Get the settings
@@ -63,7 +63,7 @@ namespace BH.Adapter.IFC
             Discipline? requestDiscipline = request.Discipline(config.Discipline);
             if (requestDiscipline == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Conflicting disciplines have been detected.");
+                BH.Engine.Base.Compute.RecordError("Conflicting disciplines have been detected.");
                 return new List<IBHoMObject>();
             }
 

--- a/IFC_Adapter/CRUD/Update.cs
+++ b/IFC_Adapter/CRUD/Update.cs
@@ -71,11 +71,11 @@ namespace BH.Adapter.IFC
                 }
                 catch (Exception e)
                 {
-                    BH.Engine.Reflection.Compute.RecordError($"Update of the IFC element based on BHoM object failed. BHoM_Guid:{obj.BHoM_Guid}\nException message: {e.Message}");
+                    BH.Engine.Base.Compute.RecordError($"Update of the IFC element based on BHoM object failed. BHoM_Guid:{obj.BHoM_Guid}\nException message: {e.Message}");
                 }
             }
 
-            BH.Engine.Reflection.Compute.RecordWarning("Update of IFC elements is currently limited to updating the existing properties.");
+            BH.Engine.Base.Compute.RecordWarning("Update of IFC elements is currently limited to updating the existing properties.");
             
             return true;
         }

--- a/IFC_Adapter/IfcAdapter.cs
+++ b/IFC_Adapter/IfcAdapter.cs
@@ -21,7 +21,7 @@
  */
 
 using BH.oM.Adapters.IFC;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System;
 using System.ComponentModel;
 using Xbim.Ifc;
@@ -74,13 +74,13 @@ namespace BH.Adapter.IFC
         {
             if (string.IsNullOrWhiteSpace(location))
             {
-                BH.Engine.Reflection.Compute.RecordError("Please specifiy a valid target location.");
+                BH.Engine.Base.Compute.RecordError("Please specifiy a valid target location.");
                 return false;
             }
 
             if (!location.ToLower().EndsWith(".ifc"))
             {
-                BH.Engine.Reflection.Compute.RecordError("The file needs to be in .ifc format.");
+                BH.Engine.Base.Compute.RecordError("The file needs to be in .ifc format.");
                 return false;
             }
 
@@ -101,7 +101,7 @@ namespace BH.Adapter.IFC
             }
             catch (Exception ex)
             {
-                BH.Engine.Reflection.Compute.RecordError($"The file failed to load with the following error:\n{ex.Message}");
+                BH.Engine.Base.Compute.RecordError($"The file failed to load with the following error:\n{ex.Message}");
                 return false;
             }
             

--- a/IFC_Adapter/Methods/Compute/CastToIfcObject.cs
+++ b/IFC_Adapter/Methods/Compute/CastToIfcObject.cs
@@ -35,7 +35,7 @@ namespace BH.Adapter.IFC
         {
             IfcObject cast = ifcObject as IfcObject;
             if (cast == null)
-                BH.Engine.Reflection.Compute.RecordError($"The provided IFC object of type {ifcObject.GetType().Name} could not be cast to {nameof(IfcObject)}.");
+                BH.Engine.Base.Compute.RecordError($"The provided IFC object of type {ifcObject.GetType().Name} could not be cast to {nameof(IfcObject)}.");
 
             return cast;
         }

--- a/IFC_Adapter/Methods/Convert/Environment/FromIFC/Space.cs
+++ b/IFC_Adapter/Methods/Convert/Environment/FromIFC/Space.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.IFC
         {
             if (element == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("The IFC element could not be converted because it was null.");
+                BH.Engine.Base.Compute.RecordError("The IFC element could not be converted because it was null.");
                 return null;
             }
 

--- a/IFC_Adapter/Methods/Convert/FromIfc.cs
+++ b/IFC_Adapter/Methods/Convert/FromIfc.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.IFC
             IEnumerable<IBHoMObject> result = FromIfc(element as dynamic, discipline, settings);
             if (result == null)
             {
-                BH.Engine.Reflection.Compute.RecordError($"IFC element conversion to BHoM failed for discipline {discipline}. A CustomObject is returned instead.");
+                BH.Engine.Base.Compute.RecordError($"IFC element conversion to BHoM failed for discipline {discipline}. A CustomObject is returned instead.");
                 return new List<IBHoMObject> { new CustomObject { Name = element.Name } };
             }
 

--- a/IFC_Adapter/Methods/Convert/Physical/FromIFC/Floor.cs
+++ b/IFC_Adapter/Methods/Convert/Physical/FromIFC/Floor.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.IFC
         {
             if (element == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("The IFC element could not be converted because it was null.");
+                BH.Engine.Base.Compute.RecordError("The IFC element could not be converted because it was null.");
                 return null;
             }
 

--- a/IFC_Adapter/Methods/Convert/Physical/FromIFC/ReinforcingBar.cs
+++ b/IFC_Adapter/Methods/Convert/Physical/FromIFC/ReinforcingBar.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.IFC
         {
             if (element == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("The IFC element could not be converted because it was null.");
+                BH.Engine.Base.Compute.RecordError("The IFC element could not be converted because it was null.");
                 return null;
             }
 

--- a/IFC_Adapter/Methods/Modify/CopyIfcPropertiesFromFragment.cs
+++ b/IFC_Adapter/Methods/Modify/CopyIfcPropertiesFromFragment.cs
@@ -66,13 +66,13 @@ namespace BH.Adapter.IFC
                                 }
                                 catch
                                 {
-                                    BH.Engine.Reflection.Compute.RecordError($"Property named {prop.Name} could not be set because the provided value has wrong type.\nElement name: {target.Name}, Element Id: {target.GlobalId}.");
+                                    BH.Engine.Base.Compute.RecordError($"Property named {prop.Name} could not be set because the provided value has wrong type.\nElement name: {target.Name}, Element Id: {target.GlobalId}.");
                                     continue;
                                 }
                                 target.SetPropertySingleValue(propSet.Name, prop.Name, newValue);
 
                                 if (set == true)
-                                    BH.Engine.Reflection.Compute.RecordWarning($"Ifc element has more than one property named {prop.Name}, all of them have been updated.\nElement name: {target.Name}, Element Id: {target.GlobalId}.");
+                                    BH.Engine.Base.Compute.RecordWarning($"Ifc element has more than one property named {prop.Name}, all of them have been updated.\nElement name: {target.Name}, Element Id: {target.GlobalId}.");
 
                                 set = true;
                             }
@@ -80,7 +80,7 @@ namespace BH.Adapter.IFC
                     }
 
                     if (set == false)
-                        BH.Engine.Reflection.Compute.RecordWarning($"Ifc element does not own any property named {prop.Name}, so it has not been updated.\nElement name: {target.Name}, Element Id: {target.GlobalId}.");
+                        BH.Engine.Base.Compute.RecordWarning($"Ifc element does not own any property named {prop.Name}, so it has not been updated.\nElement name: {target.Name}, Element Id: {target.GlobalId}.");
                 }
             }
         }

--- a/IFC_Adapter/Methods/Query/IfcEntities.cs
+++ b/IFC_Adapter/Methods/Query/IfcEntities.cs
@@ -53,13 +53,13 @@ namespace BH.Adapter.IFC
             
             if (!typeof(IBHoMObject).IsAssignableFrom(request.Type))
             {
-                BH.Engine.Reflection.Compute.RecordError($"Input type {request.Type} is not a BHoM type.");
+                BH.Engine.Base.Compute.RecordError($"Input type {request.Type} is not a BHoM type.");
                 return null;
             }
 
             if (request.Type == typeof(IBHoMObject) || request.Type == typeof(BHoMObject) || request.Type == typeof(IMaterialProperties))
             {
-                BH.Engine.Reflection.Compute.RecordError($"It is not allowed to pull elements of type {request.Type} because it is too general, please try to narrow the filter down.");
+                BH.Engine.Base.Compute.RecordError($"It is not allowed to pull elements of type {request.Type} because it is too general, please try to narrow the filter down.");
                 return null;
             }
 
@@ -75,7 +75,7 @@ namespace BH.Adapter.IFC
 
         public static List<IPersistEntity> IfcEntities(this Xbim.Ifc.IfcStore model, IRequest request)
         {
-            BH.Engine.Reflection.Compute.RecordError($"Request of type {request.GetType()} is not supported.");
+            BH.Engine.Base.Compute.RecordError($"Request of type {request.GetType()} is not supported.");
             return null;
         }
 

--- a/IFC_Adapter/Methods/Query/Meshes.cs
+++ b/IFC_Adapter/Methods/Query/Meshes.cs
@@ -41,13 +41,13 @@ namespace BH.Adapter.IFC
         {
             if (instance == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("The meshes could not be extracted because the IFC element is null.");
+                BH.Engine.Base.Compute.RecordError("The meshes could not be extracted because the IFC element is null.");
                 return null;
             }
 
             if (context == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("The meshes could not be extracted because the 3D model context is null.");
+                BH.Engine.Base.Compute.RecordError("The meshes could not be extracted because the 3D model context is null.");
                 return null;
             }
 
@@ -77,7 +77,7 @@ namespace BH.Adapter.IFC
         {
             if (shape == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("The meshes could not be extracted because the shape triangulation model is null.");
+                BH.Engine.Base.Compute.RecordError("The meshes could not be extracted because the shape triangulation model is null.");
                 return null;
             }
 

--- a/IFC_Engine/Create/IfcPullConfig.cs
+++ b/IFC_Engine/Create/IfcPullConfig.cs
@@ -21,7 +21,7 @@
  */
 
 using BH.oM.Adapters.IFC;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System.ComponentModel;
 
 namespace BH.Engine.Adapters.IFC

--- a/IFC_Engine/IFC_Engine.csproj
+++ b/IFC_Engine/IFC_Engine.csproj
@@ -202,6 +202,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Create\IfcPullConfig.cs" />
+    <Compile Include="Modify\SetIfcProperties.cs" />
     <Compile Include="Modify\SetIfcProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\DefaultIfNull.cs" />

--- a/IFC_Engine/IFC_Engine.csproj
+++ b/IFC_Engine/IFC_Engine.csproj
@@ -49,18 +49,22 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_oM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Dimensional_oM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_Engine">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -92,14 +96,17 @@
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Physical_oM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>

--- a/IFC_Engine/Modify/SetIfcProperties.cs
+++ b/IFC_Engine/Modify/SetIfcProperties.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
@@ -36,25 +36,31 @@ namespace BH.Engine.Adapters.IFC
         /****              Public methods               ****/
         /***************************************************/
 
-        [Description("Attaches property to a BHoM object, which will be applied to a correspondent IFC element on Push.")]
-        [Input("bHoMObject", "BHoMObject to which the property will be attached.")]
-        [Input("propName", "Name of the property to be attached.")]
-        [Input("value", "Value of the property to be attached.")]
+        [Description("Attaches properties to a BHoM object, which will be applied to a correspondent IFC element on Push.")]
+        [Input("bHoMObject", "BHoMObject to which the properties will be attached.")]
+        [Input("propNames", "Names of the properties to be attached.")]
+        [Input("values", "Values of the properties to be attached.")]
         [Output("bHoMObject")]
-        public static IBHoMObject SetIfcProperty(this IBHoMObject bHoMObject, string propName, object value)
+        public static IBHoMObject SetIfcProperties(this IBHoMObject bHoMObject, List<string> propNames, List<object> values)
         {
             if (bHoMObject == null)
                 return null;
 
-            List<IfcProperty> properties = new List<IfcProperty> { new IfcProperty { Name = propName, Value = value } };
+            if (propNames.Count != values.Count)
+            {
+                BH.Engine.Base.Compute.RecordError("Number of input names needs to be equal to the number of input values. Properties have not been set.");
+                return bHoMObject;
+            }
+
+            List<IfcProperty> properties = propNames.Zip(values, (x, y) => new IfcProperty { Name = x, Value = y }).ToList();
 
             IfcPropertiesToPush existingFragment = bHoMObject.Fragments.FirstOrDefault(x => x is IfcPropertiesToPush) as IfcPropertiesToPush;
             if (existingFragment != null)
             {
-                foreach (IfcProperty prop in existingFragment.Properties)
+                foreach (IfcProperty property in existingFragment.Properties)
                 {
-                    if (prop.Name != propName)
-                        properties.Add(prop);
+                    if (propNames.All(x => property.Name != x))
+                        properties.Add(property);
                 }
             }
 

--- a/IFC_Engine/Modify/SetIfcProperty.cs
+++ b/IFC_Engine/Modify/SetIfcProperty.cs
@@ -23,7 +23,7 @@
 using BH.Engine.Base;
 using BH.oM.Adapters.IFC.Properties;
 using BH.oM.Base;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -64,7 +64,7 @@ namespace BH.Engine.Adapters.IFC
             obj.Fragments.AddOrReplace(fragment);
 
             // Warning to be removed once the support for units is added
-            BH.Engine.Reflection.Compute.RecordWarning("Please not that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
+            BH.Engine.Base.Compute.RecordWarning("Please not that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
 
             return obj;
         }
@@ -83,7 +83,7 @@ namespace BH.Engine.Adapters.IFC
 
             if (propNames.Count != values.Count)
             {
-                BH.Engine.Reflection.Compute.RecordError("Number of input names needs to be equal to the number of input values. Properties have not been set.");
+                BH.Engine.Base.Compute.RecordError("Number of input names needs to be equal to the number of input values. Properties have not been set.");
                 return bHoMObject;
             }
 
@@ -105,7 +105,7 @@ namespace BH.Engine.Adapters.IFC
             obj.Fragments.AddOrReplace(fragment);
 
             // Warning to be removed once the support for units is added
-            BH.Engine.Reflection.Compute.RecordWarning("Please not that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
+            BH.Engine.Base.Compute.RecordWarning("Please not that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
 
             return obj;
         }

--- a/IFC_Engine/Query/DefaultIfNull.cs
+++ b/IFC_Engine/Query/DefaultIfNull.cs
@@ -21,7 +21,7 @@
  */
 
 using BH.oM.Adapters.IFC;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System.ComponentModel;
 
 namespace BH.Engine.Adapters.IFC
@@ -40,7 +40,7 @@ namespace BH.Engine.Adapters.IFC
             if (settings == null)
             {
                 settings = new IfcSettings();
-                BH.Engine.Reflection.Compute.RecordNote("Settings have not been specified, default settings are used.");
+                BH.Engine.Base.Compute.RecordNote("Settings have not been specified, default settings are used.");
             }
 
             return settings;

--- a/IFC_Engine/Query/Discipline.cs
+++ b/IFC_Engine/Query/Discipline.cs
@@ -21,7 +21,7 @@
  */
  
 using BH.oM.Data.Requests;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System;
 using System.ComponentModel;
 using BH.Engine.Data;

--- a/IFC_Engine/Query/GetIfcProperties.cs
+++ b/IFC_Engine/Query/GetIfcProperties.cs
@@ -23,7 +23,7 @@
 using BH.Engine.Base;
 using BH.oM.Adapters.IFC.Properties;
 using BH.oM.Base;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -45,7 +45,7 @@ namespace BH.Engine.Adapters.IFC
                 return null;
 
             // Warning to be removed once the support for units is added
-            BH.Engine.Reflection.Compute.RecordWarning("Please note that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
+            BH.Engine.Base.Compute.RecordWarning("Please note that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
 
             IfcPulledProperties pullFragment = bHoMObject.FindFragment<IfcPulledProperties>();
             IfcPropertiesToPush pushFragment = bHoMObject.FindFragment<IfcPropertiesToPush>();
@@ -71,7 +71,7 @@ namespace BH.Engine.Adapters.IFC
                 }
 
                 if (mixed)
-                    BH.Engine.Reflection.Compute.RecordNote("Some of the properties were retrieved from collection of pulled ones, some from the ones meant to be pushed.");
+                    BH.Engine.Base.Compute.RecordNote("Some of the properties were retrieved from collection of pulled ones, some from the ones meant to be pushed.");
             }
 
             return result;

--- a/IFC_Engine/Query/GetIfcPropertyValue.cs
+++ b/IFC_Engine/Query/GetIfcPropertyValue.cs
@@ -22,7 +22,7 @@
 
 using BH.oM.Adapters.IFC.Properties;
 using BH.oM.Base;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System.ComponentModel;
 using System.Linq;
 using System.Collections.Generic;
@@ -46,7 +46,7 @@ namespace BH.Engine.Adapters.IFC
                 return null;
 
             // Warning to be removed once the support for units is added
-            BH.Engine.Reflection.Compute.RecordWarning("Please not that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
+            BH.Engine.Base.Compute.RecordWarning("Please not that IFC_Toolkit currently does not support units in property conversion - please be careful when working with dimensions etc.");
 
             IfcPropertiesToPush pushFragment = bHoMObject.FindFragment<IfcPropertiesToPush>();
             if (pushFragment?.Properties != null)
@@ -76,7 +76,7 @@ namespace BH.Engine.Adapters.IFC
                         IfcProperty prop = typePullFragment.Properties.FirstOrDefault(x => x.Name == propertyName);
                         if (prop != null)
                         {
-                            Engine.Reflection.Compute.RecordWarning("The value for property " + propertyName + " for the object with BHoM_Guid " + bHoMObject.BHoM_Guid + " has been retrieved from its property " + bHoMPropEntry.Key + ".");
+                            Engine.Base.Compute.RecordWarning("The value for property " + propertyName + " for the object with BHoM_Guid " + bHoMObject.BHoM_Guid + " has been retrieved from its property " + bHoMPropEntry.Key + ".");
                             return prop.Value;
                         }
                     }

--- a/IFC_Engine/Query/IfcMeshes.cs
+++ b/IFC_Engine/Query/IfcMeshes.cs
@@ -23,7 +23,7 @@
 using BH.oM.Adapters.IFC;
 using BH.oM.Base;
 using BH.oM.Geometry;
-using BH.oM.Reflection.Attributes;
+using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/IFC_oM/Settings/IfcSettings.cs
+++ b/IFC_oM/Settings/IfcSettings.cs
@@ -20,12 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System.ComponentModel;
 
 namespace BH.oM.Adapters.IFC
 {
     [Description("Settings of the IFC adapter.")]
-    public class IfcSettings
+    public class IfcSettings : BHoMObject
     {
         /***************************************************/
         /****             Public Properties             ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #15
Closes #17 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
#15: one of the files from [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FIFC%5FToolkit&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) should be fine.
#17: run GH and check if the autogenerated constructor is available through the UI.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->